### PR TITLE
Make imap.py script more configurable and turn lamp off after new email has been read.

### DIFF
--- a/scripts/imap.conf.dist
+++ b/scripts/imap.conf.dist
@@ -1,4 +1,6 @@
 host: example.org
 username: john.doe
 password: secret
+mailbox: INBOX
 refresh-time-interval: 300
+colour: blue

--- a/scripts/imap.py
+++ b/scripts/imap.py
@@ -24,8 +24,8 @@ import usblamp
 
 configFile = os.path.join(os.path.dirname(__file__), 'imap.conf')
 try:
-    with open(configFile) as f:
-        conf = yaml.load(f)
+	with open(configFile) as f:
+		conf = yaml.load(f)
 except IOError, e:
 	print(e)
 	sys.exit(1);
@@ -38,13 +38,15 @@ while True:
 	print msgnums
 	if msgnums[0]:
 		usblamp.switchTo(conf['colour'])
+	else:
+		usblamp.switchTo('#000')
 
 	mailbox.close()
 	mailbox.logout()
 
-        try:
-            time.sleep(conf['refresh-time-interval'])
-        except (KeyboardInterrupt, SystemExit):
-            usblamp.switchTo('#000')
-            sys.exit()
+	try:
+		time.sleep(conf['refresh-time-interval'])
+	except (KeyboardInterrupt, SystemExit):
+		usblamp.switchTo('#000')
+		sys.exit()
 

--- a/scripts/imap.py
+++ b/scripts/imap.py
@@ -33,14 +33,18 @@ except IOError, e:
 while True:
 	mailbox = imaplib.IMAP4_SSL(conf['host'])
 	mailbox.login(conf['username'], conf['password'])
-	mailbox.select()
+	mailbox.select(conf['mailbox'])
 	typ, msgnums = mailbox.search(None,'UnSeen')
 	print msgnums
 	if msgnums[0]:
-		usblamp.switchTo('blue')
+		usblamp.switchTo(conf['colour'])
 
 	mailbox.close()
 	mailbox.logout()
 
-	time.sleep(conf['refresh-time-interval'])
+        try:
+            time.sleep(conf['refresh-time-interval'])
+        except (KeyboardInterrupt, SystemExit):
+            usblamp.switchTo('#000')
+            sys.exit()
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -83,6 +83,8 @@ Color getColor(const char* param, unsigned char maxval) {
       ret = Color(0,maxval,maxval);
     } else if (!strcmp(color, "yellow")) {
       ret = Color(maxval,maxval,0);
+    } else if (!strcmp(color, "pink")) {
+      ret = Color(maxval,0, maxval);
     } else {                            // default set off
       ret = Color(0,0,0);
     }
@@ -131,7 +133,7 @@ void listen(USBLamp lamp, int port) {
 
 void print_help() {
 	std::cout << "Usage: usblamp [-s] [-r <num>[,<delay>]] [-p <port>] [-d <delay>] color[,<delay>] [color...]" << std::endl;
-	std::cout << "   valid colors: [red blue green white magenta cyan yellow off], #rrggbb (hex) or #rgb (hex)" << std::endl;
+	std::cout << "   valid colors: [red blue green white magenta pink cyan yellow off], #rrggbb (hex) or #rgb (hex)" << std::endl;
 	std::cout << "   an optional parameter color[,<delay>] will overwrite the -d option for that color" << std::endl << std::endl;
 	std::cout << "   -s will switch between colors and disable fade" << std::endl << std::endl;
 	std::cout << "   -r <num>[,<delay>] will repeat the color sequence <num> times (default is 0)" << std::endl;


### PR DESCRIPTION
I got a email-notifier lamp from my wife as a Christmas present, and tweaked imap.py to make it turn the lamp off after a new email has been opened, and more configurable too (new settings are 'colour' and 'mailbox'). I've also made the usblamp tool recognise 'pink' as a colour.